### PR TITLE
Changing model JSON format

### DIFF
--- a/feltlabs/core/models/analytics_model.py
+++ b/feltlabs/core/models/analytics_model.py
@@ -216,7 +216,7 @@ class SingleModel(AvgModel):
 
 
 class Model(BaseModel):
-    """Model class for single or multiple analytics."""
+    """Model class for running single or multiple analytics."""
 
     model_type: str = "analytics"
     models = []

--- a/feltlabs/core/models/base_model.py
+++ b/feltlabs/core/models/base_model.py
@@ -41,7 +41,7 @@ class BaseModel(ABC):
             bytes of JSON file
         """
         data = self._export_data()
-        data_bytes = json_dump(data)
+        data_bytes = json_dump({"model_definition": data})
         if filename:
             with open(filename, "wb") as f:
                 f.write(data_bytes)
@@ -196,23 +196,6 @@ class AvgModel(BaseModel):
         """
         self.sample_size.extend([m.sample_size[0] for m in models])
         self._aggregate(models)
-
-    def export_model(self, filename: Optional[PathType] = None) -> bytes:
-        """Export model to bytes and optionally store it as JSON file.
-
-        Args:
-            filename: path to exported file
-
-        Returns:
-            bytes of JSON file
-        """
-        data = self._export_data()
-        data_bytes = json_dump(data)
-        if filename:
-            with open(filename, "wb") as f:
-                f.write(data_bytes)
-
-        return data_bytes
 
     def _agg_models_op(self, op: Callable, models: List["AvgModel"]) -> None:
         """Perform aggregation operation on list of models.

--- a/feltlabs/core/storage.py
+++ b/feltlabs/core/storage.py
@@ -24,7 +24,7 @@ def load_model(file: Union[FileType, dict], experimental: bool = True) -> BaseMo
     Returns:
         scikit-learn model
     """
-    data = json_load(file)
+    data = json_load(file)["model_definition"]
 
     if data["model_type"] == "sklearn":
         return sklearn_model.Model(data)

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ requirements = parse_requirements(PATH / "requirements.txt")
 
 setup(
     name="feltlabs",
-    version="0.4.4",
+    version="0.5.0",
     packages=find_packages(),
     maintainer="FELT Labs",
     maintainer_email="info@bretahajek.com",

--- a/tests/test_solo_training.py
+++ b/tests/test_solo_training.py
@@ -12,8 +12,10 @@ from feltlabs.model import load_model
 # Right now it uses test dataset
 
 model_def = {
-    "model_type": "sklearn",
-    "model_name": "LinearRegression",
+    "model_definition": {
+        "model_type": "sklearn",
+        "model_name": "LinearRegression",
+    }
 }
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -17,8 +17,10 @@ aggregation_key = PrivateKey.generate()
 scientist_key = PrivateKey.generate()
 
 model_def = {
-    "model_type": "sklearn",
-    "model_name": "LinearRegression",
+    "model_definition": {
+        "model_type": "sklearn",
+        "model_name": "LinearRegression",
+    }
 }
 
 


### PR DESCRIPTION
The format is very similar, but model definition is put into single key `model_definition`  
**Previously:**
```JSON
{
  "model_name": "...",
  "model_type": "...",
  "init_params": "...",
}
```
**New model format:**
```JSON
{
  "model_definition": {
    "model_name": "...",
    "model_type": "...",
    "init_params": "...",
  }
}
```
The model definition can hold a list of models for the `analytics` model type. For example
```JSON
{
  "model_definition": [
    {
      "model_name": "Mean",
      "model_type": "analytics",
      "init_params": "...",
    },
    {
      "model_name": "Sum",
      "model_type": "analytics",
      "init_params": "...",
    },
  ]
}
```